### PR TITLE
Updating Vault constructor 

### DIFF
--- a/Vault.js
+++ b/Vault.js
@@ -14,6 +14,14 @@ const assert = require('assert');
 
 // Internal function - create new https agent
 const getHttpsAgent = function(certificate, key, cacert) {
+
+  if(!certificate && !key && cacert) {
+    return new https.Agent({
+      // CA cert from Hashicorp Vault PKI
+      ca: fs.readFileSync(cacert)
+    });
+  }
+
   return new https.Agent({
     // Client certificate
     cert: fs.readFileSync(certificate),


### PR DESCRIPTION
Updating Vault constructor to allow constructing https agent only using cacerts. I work in an environment where we have trusted ca certs and don't require client certs. 