### PR TITLE
Supporting cert login authentication method

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -51,6 +51,8 @@ const config = {
   ldapReadGroup: [ 'groups', 'get'],
   ldapListUsers: [ 'users', 'list'],
   ldapListGroups: [ 'groups', 'list'],
+  certRootPath:'auth/cert',
+  certLogin: [ 'login', 'post'],
   userpassRootPath: 'auth/userpass',
   userpassCreateUser: [ 'users', 'post'],
   userpassReadUser: [ 'users', 'get'],

--- a/Vault.js
+++ b/Vault.js
@@ -976,7 +976,40 @@ class Vault {
       throw parseAxiosError(err);
     }
   }
+  
+  //
+  // cert auth method API endpoints
+  //
 
+  /**
+  * @param {String} mount
+  * @param {String} certName
+  * @returns {Promise<Object>}
+  */
+   async loginWithCert(certName, mount) {
+    let rootPath= "";
+    if (mount) {
+      rootPath = mount;
+    } else if (this.rootPath) {
+      rootPath = this.rootPath;
+    } else {
+      rootPath = config.certRootPath;
+    }
+    const Options = {
+      url: `${rootPath}/${config.certLogin[0]}`,
+      method: config.certLogin[1],
+      data: {
+        "name": certName
+      }
+    };
+
+    try {
+      const response = await this.instance(Options);
+      return parseAxiosResponse(response);
+    } catch(err) {
+      throw parseAxiosError(err);
+    }
+  }
 
   //
   // Userpass auth method API endpoints


### PR DESCRIPTION
implemented as https://www.vaultproject.io/api/auth/cert#login-with-tls-certificate-method
httpsAgent already included the cert/key/cacert so we can use it directly in the axiosInstance