### PR TITLE
Refactor/typings

### DIFF
--- a/Vault.d.ts
+++ b/Vault.d.ts
@@ -253,7 +253,7 @@ export type CreateTokenParams = {
 	id?: string;
 	role_name?: string;
 	policies?: string;
-	meta?: Record<string, any>;
+	meta?: Record<string, unknown>;
 	no_parent?: boolean;
 	no_default_policy?: boolean;
 	renewable?: boolean;
@@ -533,13 +533,13 @@ export type ReadK8sConfigResponse = {
 	disable_local_ca_jwt: boolean;
 } | ErrorResponse;
 export type CreateK8sRoleParams = {
-	bound_service_account_names?: Record<string, any>;
-	bound_service_account_namespaces?: Record<string, any>;
+	bound_service_account_names?: Record<string, unknown>;
+	bound_service_account_namespaces?: Record<string, unknown>;
 	audience?: string;
 	token_ttl?: string | number;
 	token_max_ttl?: string | number;
-	token_policies?: Record<string, any>;
-	token_bound_cidrs?: Record<string, any>;
+	token_policies?: Record<string, unknown>;
+	token_bound_cidrs?: Record<string, unknown>;
 	token_explicit_max_ttl?: string | number;
 	token_no_default_policy?: boolean;
 	token_num_uses?: number;
@@ -563,7 +563,7 @@ export type LoginWithAppRoleResponse = {
 	client_token: string;
 	accessor: string;
 	token_policies: string[];
-	metadata: Record<string, any> | null;
+	metadata: Record<string, unknown> | null;
 	lease_duration: number;
 	renewable: boolean;
 } | ErrorResponse;
@@ -930,14 +930,14 @@ export type ReadKVEngineConfigResponse = {
 } | ErrorResponse;
 export type CreateKVSecretResponse = {
 	created_time: string;
-	custom_metadata: Record<string, any>;
+	custom_metadata: Record<string, unknown>;
 	deletion_time: string;
 	destroyed: boolean;
 	version: number;
 } | ErrorResponse;
 export type UpdateKVSecretResponse = {
 	created_time: string;
-	custom_metadata: Record<string, any>;
+	custom_metadata: Record<string, unknown>;
 	deletion_time: string;
 	destroyed: boolean;
 	version: number;
@@ -951,7 +951,6 @@ export type EliminateKVSecretResponse = {} | ErrorResponse;
 export type ListKVSecretsResponse = {
 	keys: string[];
 } | ErrorResponse;
-
 
 declare module "hashi-vault-js" {
 	class Vault {
@@ -1063,10 +1062,10 @@ declare module "hashi-vault-js" {
 		checkADCredOut(token: string, params: CheckADCredOutParams, mount?: string): Promise<CheckADCredOutResponse>;
 		checkADCredInt(token: string, params: CheckADCredInParams, forceMode: boolean, mount?: string): Promise<CheckADCredInResponse>;
 		getADCredSatus(token: string, setName: string, mount?: string): Promise<GetADCredSatusResponse>;
-		updateKVEngineConfig(token: string, data: Record<string, any>, mount?: string): Promise<UpdateKVEngineConfigResponse>;
+		updateKVEngineConfig(token: string, data: Record<string, unknown>, mount?: string): Promise<UpdateKVEngineConfigResponse>;
 		readKVEngineConfig(token: string, mount?: string): Promise<ReadKVEngineConfigResponse>;
-		createKVSecret(token: string, name: string, secrets: Record<string, any>, mount?: string): Promise<CreateKVSecretResponse>;
-		updateKVSecret(token: string, name: string, secrets: Record<string, any>, version: number, mount?: string): Promise<UpdateKVSecretResponse>;
+		createKVSecret(token: string, name: string, secrets: Record<string, unknown>, mount?: string): Promise<CreateKVSecretResponse>;
+		updateKVSecret(token: string, name: string, secrets: Record<string, unknown>, version: number, mount?: string): Promise<UpdateKVSecretResponse>;
 		readKVSecret(token: string, name: string, version?: number, mount?: string): Promise<ReadKVSecretResponse>;
 		deleteLatestVerKVSecret(token: string, name: string, mount?: string): Promise<DeleteLatestVerKVSecretResponse>;
 		deleteVersionsKVSecret(token: string, name: string, versions: number[], mount?: string): Promise<DeleteVersionsKVSecretResponse>;

--- a/Vault.d.ts
+++ b/Vault.d.ts
@@ -942,7 +942,16 @@ export type UpdateKVSecretResponse = {
 	destroyed: boolean;
 	version: number;
 } | ErrorResponse;
-export type ReadKVSecretResponse = {} | ErrorResponse;
+export type ReadKVSecretResponse = {
+	data: Record<string, unknown>;
+	metadata: {
+		created_time: string;
+		custom_metadata: Record<string, unknown> | null;
+		deletion_time: string;
+		destroyed: boolean;
+		version: number;
+	}
+} | ErrorResponse;
 export type DeleteLatestVerKVSecretResponse = {} | ErrorResponse;
 export type DeleteVersionsKVSecretResponse = {} | ErrorResponse;
 export type UndeleteVersionsKVSecretResponse = {} | ErrorResponse;

--- a/Vault.d.ts
+++ b/Vault.d.ts
@@ -7,12 +7,7 @@
 import type { Axios, AxiosProxyConfig } from "axios";
 import type { Agent } from "https";
 
-export type VaultConfig = {
-	/**
-	 * Indicates if the HTTP request to the Vault server should use
-	 * HTTPS (secure) or HTTP (non-secure) protocol
-	 */
-	https?: boolean;
+export type CertConfig = {
 	/**
 	 * If https is true, then provide client certificate, client key and
 	 * the root CA cert.
@@ -28,6 +23,14 @@ export type VaultConfig = {
 	 * @example './path/to/your/cacert.crt
 	 */
 	cacert: string;
+};
+
+export type VaultConfig = {
+	/**
+	 * Indicates if the HTTP request to the Vault server should use
+	 * HTTPS (secure) or HTTP (non-secure) protocol
+	 */
+	https?: boolean;
 	/**
 	 * Indicate the server name/IP, port and API version for the Vault instance,
 	 * all paths are relative to this one
@@ -53,7 +56,7 @@ export type VaultConfig = {
 	 * Namespace (multi-tenancy) feature available on all Vault Enterprise versions
 	 */
 	namespace?: string;
-}
+} & Partial<CertConfig>;
 
 export type CertificateFormat = "der" | "pem";
 export type KeyType = "rsa" | "ec";

--- a/Vault.d.ts
+++ b/Vault.d.ts
@@ -15,8 +15,8 @@ export type VaultConfig = {
 	https?: boolean;
 	/**
 	 * If https is true, then provide client certificate, client key and
-   * the root CA cert.
-   * Client cert and key are optional now.
+	 * the root CA cert.
+	 * Client cert and key are optional now.
 	 * @example './path/to/your/cert.crt'
 	 */
 	cert: string;
@@ -30,13 +30,13 @@ export type VaultConfig = {
 	cacert: string;
 	/**
 	 * Indicate the server name/IP, port and API version for the Vault instance,
-   * all paths are relative to this one
+	 * all paths are relative to this one
 	 */
 	baseUrl?: string;
 	/**
 	 * Sets the root path after the base URL, it translates to a
-   * partition inside the Vault where the secret engine / auth method was enabled.
-   * Can be passed individually on each function through mount parameter
+	 * partition inside the Vault where the secret engine / auth method was enabled.
+	 * Can be passed individually on each function through mount parameter
 	 */
 	rootPath: string;
 	/**
@@ -45,8 +45,8 @@ export type VaultConfig = {
 	timeout: number;
 	/**
 	 * If should use a proxy or not by the HTTP request
-   * Example:
-   * proxy: { host: proxy.ip, port: proxy.port }
+	 * Example:
+	 * proxy: { host: proxy.ip, port: proxy.port }
 	 */
 	proxy?: AxiosProxyConfig | boolean;
 	/**
@@ -69,100 +69,100 @@ export type ErrorResponse = {
 };
 
 interface Cpu {
-  cpu: number;
-  vendorId: string;
-  family: string;
-  model: string;
-  stepping: number;
-  physicalId: string;
-  coreId: string;
-  cores: number;
-  modelName: string;
-  mhz: number;
-  cacheSize: number;
+	cpu: number;
+	vendorId: string;
+	family: string;
+	model: string;
+	stepping: number;
+	physicalId: string;
+	coreId: string;
+	cores: number;
+	modelName: string;
+	mhz: number;
+	cacheSize: number;
 	flags: string[];
-  microcode: string;
+	microcode: string;
 }
 
 interface CpuTime {
-  cpu: string;
-  user: number;
-  system: number;
-  idle: number;
-  nice: number;
-  iowait: number;
-  irq: number;
-  softirq: number;
-  steal: number;
-  guest: number;
-  guestNice: number;
+	cpu: string;
+	user: number;
+	system: number;
+	idle: number;
+	nice: number;
+	iowait: number;
+	irq: number;
+	softirq: number;
+	steal: number;
+	guest: number;
+	guestNice: number;
 }
 
 interface Disk {
-  path: string;
-  fstype: string;
-  total: number;
-  free: number;
-  used: number;
-  usedPercent: number;
-  inodesTotal: number;
-  inodesUsed: number;
-  inodesFree: number;
-  inodesUsedPercent: number;
+	path: string;
+	fstype: string;
+	total: number;
+	free: number;
+	used: number;
+	usedPercent: number;
+	inodesTotal: number;
+	inodesUsed: number;
+	inodesFree: number;
+	inodesUsedPercent: number;
 }
 
 interface Host {
-  hostname: string;
-  uptime: number;
-  bootTime: number;
-  procs: number;
-  os: string;
-  platform: string;
-  platformFamily: string;
-  platformVersion: string;
-  kernelVersion: string;
-  kernelArch: string;
-  virtualizationSystem: string;
-  virtualizationRole: string;
-  hostid: string;
+	hostname: string;
+	uptime: number;
+	bootTime: number;
+	procs: number;
+	os: string;
+	platform: string;
+	platformFamily: string;
+	platformVersion: string;
+	kernelVersion: string;
+	kernelArch: string;
+	virtualizationSystem: string;
+	virtualizationRole: string;
+	hostid: string;
 }
 
 interface Memory {
-  total: number;
-  available: number;
-  used: number;
-  usedPercent: number;
-  free: number;
-  active: number;
-  inactive: number;
-  wired: number;
-  laundry: number;
-  buffers: number;
-  cached: number;
-  writeback: number;
-  dirty: number;
-  writebacktmp: number;
-  shared: number;
-  slab: number;
-  sreclaimable: number;
-  sunreclaim: number;
-  pagetables: number;
-  swapcached: number;
-  commitlimit: number;
-  committedas: number;
-  hightotal: number;
-  highfree: number;
-  lowtotal: number;
-  lowfree: number;
-  swaptotal: number;
-  swapfree: number;
-  mapped: number;
-  vmalloctotal: number;
-  vmallocused: number;
-  vmallocchunk: number;
-  hugepagestotal: number;
-  hugepagesfree: number;
-  hugepagesize: number;
+	total: number;
+	available: number;
+	used: number;
+	usedPercent: number;
+	free: number;
+	active: number;
+	inactive: number;
+	wired: number;
+	laundry: number;
+	buffers: number;
+	cached: number;
+	writeback: number;
+	dirty: number;
+	writebacktmp: number;
+	shared: number;
+	slab: number;
+	sreclaimable: number;
+	sunreclaim: number;
+	pagetables: number;
+	swapcached: number;
+	commitlimit: number;
+	committedas: number;
+	hightotal: number;
+	highfree: number;
+	lowtotal: number;
+	lowfree: number;
+	swaptotal: number;
+	swapfree: number;
+	mapped: number;
+	vmalloctotal: number;
+	vmallocused: number;
+	vmallocchunk: number;
+	hugepagestotal: number;
+	hugepagesfree: number;
+	hugepagesize: number;
 }
 
 
@@ -177,31 +177,31 @@ export type HealthCheckParams = {
 	uninitcode?: number;
 };
 export type HealthCheckResponse = {
-  initialized: boolean;
-  sealed: boolean;
-  standby: boolean;
-  performance_standby: boolean;
-  replication_performance_mode: string;
-  replication_dr_mode: string;
-  server_time_utc: number;
-  version: string;
-  cluster_name: string;
+	initialized: boolean;
+	sealed: boolean;
+	standby: boolean;
+	performance_standby: boolean;
+	replication_performance_mode: string;
+	replication_dr_mode: string;
+	server_time_utc: number;
+	version: string;
+	cluster_name: string;
 	cluster_id: string;
 } | ErrorResponse;
 export type SealStatusResponse = {
-  type: string;
-  initialized: boolean;
-  sealed: boolean;
-  t: number;
-  n: number;
-  progress: number;
-  nonce: string;
-  version: string;
-  build_date: string;
+	type: string;
+	initialized: boolean;
+	sealed: boolean;
+	t: number;
+	n: number;
+	progress: number;
+	nonce: string;
+	version: string;
+	build_date: string;
 	migration: boolean;
 	cluster_name?: string;
 	cluster_id?: string;
-  recovery_seal: boolean;
+	recovery_seal: boolean;
 	storage_type: string;
 } | ErrorResponse;
 export type SysHostInfoResponse = {
@@ -221,9 +221,9 @@ export type SysCapabilitiesSelfResponse = {
 } | ErrorResponse;
 export type SysInternalCountersResponse = {
 	request_id: string;
-  lease_id: string;
-  renewable: boolean;
-  lease_duration: number;
+	lease_id: string;
+	renewable: boolean;
+	lease_duration: number;
 	data: {
 		counters: {
 			entities: {
@@ -231,17 +231,17 @@ export type SysInternalCountersResponse = {
 			};
 		};
 	};
-  wrap_info: string | null;
-  warnings: string | null;
+	wrap_info: string | null;
+	warnings: string | null;
 	auth: string | null;
 } | ErrorResponse;
 export type SysMetricsResponse = {} | ErrorResponse;
 export type SysSealResponse = {} | ErrorResponse;
 export type SysUnsealResponse = {
 	sealed: boolean;
-  t: number;
-  n: number;
-  progress: number;
+	t: number;
+	n: number;
+	progress: number;
 	version: number;
 	cluster_name?: string;
 	cluster_version?: string;
@@ -455,19 +455,19 @@ export type SetLdapConfigParams = {
 	token_type?: string;
 };
 export type SetLdapConfigResponse = {
-  binddn: string;
+	binddn: string;
 	deny_null_bind: boolean;
-  discoverdn: boolean;
-  groupattr: string;
-  groupdn: string;
-  groupfilter: string;
-  insecure_tls: boolean;
-  starttls: boolean;
-  tls_max_version: string;
-  tls_min_version: string;
-  url: string;
-  username_as_alias: boolean;
-  userattr: string;
+	discoverdn: boolean;
+	groupattr: string;
+	groupdn: string;
+	groupfilter: string;
+	insecure_tls: boolean;
+	starttls: boolean;
+	tls_max_version: string;
+	tls_min_version: string;
+	url: string;
+	username_as_alias: boolean;
+	userattr: string;
 	userdn: string;
 } | ErrorResponse;
 export type LoginWithCertResponse = {

--- a/Vault.d.ts
+++ b/Vault.d.ts
@@ -170,14 +170,14 @@ interface Memory {
 
 
 export type HealthCheckParams = {
-	standbyok?: boolean;
-	perfstandbyok?: boolean;
-	activecode?: number;
-	standbycode?: number;
-	drsecondarycode?: number;
-	performancestandbycode?: number;
-	sealedcode?: number;
-	uninitcode?: number;
+	standbyok: boolean;
+	perfstandbyok: boolean;
+	activecode: number;
+	standbycode: number;
+	drsecondarycode: number;
+	performancestandbycode: number;
+	sealedcode: number;
+	uninitcode: number;
 };
 export type HealthCheckResponse = {
 	initialized: boolean;
@@ -967,7 +967,7 @@ declare module "hashi-vault-js" {
 		private agent: Agent | boolean;
 
 		constructor(params: VaultConfig)
-		healthCheck(params: HealthCheckParams): Promise<HealthCheckResponse>;
+		healthCheck(params?: Partial<HealthCheckParams>): Promise<HealthCheckResponse>;
 		sealStatus(): Promise<SealStatusResponse>;
 		sysHostInfo(sudoToken: string): Promise<SysHostInfoResponse>;
 		sysCapabilities(sudoToken: string, token: string, paths: string[]): Promise<SysCapabilitiesResponse>;


### PR DESCRIPTION
- Formats typings (we should probably add a linter and formatter step using a precommit hook)
- Set SSL cert parameters as optional in the config
- Switch up from using `Record<string, any>` to `Record<string, unknown>` as it's a much more safer alternative (forces user to specify type when `unknown` is used)
- Made healthcheck params optional
- Added response structure to `readKVSecret()`